### PR TITLE
Bug fix: Fixed a bug wherein the install script was exiting with the incorrect status code on failure.

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -61,6 +61,9 @@ install_tmux() {
     make -j $concurrency
     if [[ $? -eq 0 ]]; then
       make install
+    else
+        echo "Failed to install tmux ${version}"
+        exit 2
     fi
   )
 }
@@ -86,6 +89,7 @@ install_libevent() {
   if [[ $? -eq 0 ]]; then
     make install
   else
+    echo "Failed to install libevent ${libevent_version}"
     exit 2
   fi
 }


### PR DESCRIPTION
Previous behaviour: If the tmux `make` command fails, the exit code is erroneously returned as success and as a result, asdf sees it as a successful installation. 

New behaviour: Return a non-zero (failure) exit code to the script if tmux `make` fails.