### PR TITLE
add note on gotcha for utf8 issue on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@
 asdf plugin-add tmux https://github.com/aphecetche/asdf-tmux.git
 asdf install tmux <version>
 ```
+
+On MacOS it may be necessary to set a configuration option before installing.
+`export TMUX_CONFIGURE_OPTIONS="--enable-utf8proc"`
+(see: https://github.com/tmux/tmux/wiki/Installing#configure-says-must-give---enable-utf8proc-or---disable-utf8proc)


### PR DESCRIPTION
I was having an issue install tmux via asdf using this plugin. I found that setting the `TMUX_CONFIGURE_OPTIONS` environment variable to `--enable-utf8proc` fixed the issue. I added a note to the README to help others who may run into the same issue.

The install script here could also autodetect darwin and set the `TMUX_CONFIGURE_OPTIONS` environment variable to `--enable-utf8proc` if it is not already set. This would make the installation process easier for users on macOS.

cc https://github.com/aphecetche/asdf-tmux/issues/4 and https://github.com/aphecetche/asdf-tmux/issues/7
